### PR TITLE
Remove Console.Error message when decoding file

### DIFF
--- a/CloudPRNTSDKSamples/cputil/Program.cs
+++ b/CloudPRNTSDKSamples/cputil/Program.cs
@@ -83,7 +83,6 @@ namespace cputil
                         Document.ConvertFile(filename, s, format, opts);
                         s.Close();
 
-                        Console.Error.WriteLine(String.Format("Wrote output to \"{0}\"", outputfile));
                         break;
 
                     case "printarea":


### PR DESCRIPTION
This message was being written to my error logs on each call to `decode` it appears to be debugging output that is not necessary (and unwanted) in a production environment. Alternatively a settings file could be used but removing this message was the best option for our product, running in a Linux x64 environment.