### PR TITLE
Added option to convert Star Document Markup string into print job

### DIFF
--- a/CloudPRNTSDKSamples/cputil/Program.cs
+++ b/CloudPRNTSDKSamples/cputil/Program.cs
@@ -55,7 +55,7 @@ namespace cputil
                         PrintInputs();
                         break;
 
-                    case "decode":
+                    case "decode": {
                         if(args.Length - i < 3)
                         {
                             PrintHelp();
@@ -85,7 +85,16 @@ namespace cputil
 
                         Console.Error.WriteLine(String.Format("Wrote output to \"{0}\"", outputfile));
                         break;
-
+                    }
+                    case "decode-markup": {
+                        string format = args[++i];
+                        string markup_string = args[++i];
+                        byte[] bit_string = System.Text.Encoding.UTF8.GetBytes(markup_string);
+                        Stream s = Console.OpenStandardOutput();
+                        Document.Convert(bit_string, "text/vnd.star.markup", s, format, null);
+                        s.Close();
+                        break;
+                    }
                     case "printarea":
                         if(args.Length - i < 1)
                         {
@@ -263,6 +272,7 @@ namespace cputil
                 "                                        \"image/png\" or \"application/vnd.star.markup\".",
                 "  decode <format> <filename> <output> - Convert file to the specified format. Format should",
                 "                                        be provides as a media type string.",
+                "  decode-markup <format> <string>     - Convert Star Document Markup as string to text/vnd.star.markup format.",
                 "                                        decoder data is writtenn to the file specified by",
                 "                                        <output>. If output is set to \"-\" or \"[stdout]\"",
                 "                                        then data will be written to standard output.",

--- a/CloudPRNTSDKSamples/cputil/cputil.csproj
+++ b/CloudPRNTSDKSamples/cputil/cputil.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="StarMicronics.CloudPRNT-Utility" Version="1.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="StarMicronics.CloudPRNT-Utility" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Instead of creating a print job data using decode option with an input of .stm file, I thought it would be convenient to be able to create a print job data with an input of string resembling Star Document Markup.
I am integrating CloudPRNT technology into my server based on Python, so in order to create a print job for a response of GET request from a printer, invoking cputil as an external process is only the way to create a print job data.
cputil's decode option can achieve this, but it would not be convenient to generate .stm file and convert it to print job data since the contents of the paper is dynamic at least in my case.